### PR TITLE
hotfix: add base stylesheet so wp can recognise and activate theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,0 +1,20 @@
+/*!
+Theme Name: Tatteo
+Theme URI: http://tatteo.com/
+Author: RED Academy
+Author URI: http://redacademy.com
+Description: A custom WordPress theme for Tatteo
+Version: 0.6
+License: GNU General Public License v2 or later
+License URI: LICENSE
+Text Domain: tatteo
+Tags: custom-menu, featured-images, threaded-comments, translation-ready
+*/
+
+/************************************************************
+ * WARNING!
+ * THIS FILE IS NEEDED SO THAT WORDPRESS RECOGNISES THE THEME
+ * AND IS ABLE TO ACTIVATE IT IN THE ADMIN AREA OR WITH CLI
+ * IT _MUST_ CONTAIN THE INFORMATION ABOVE AT A BARE MINIMUM
+ *
+ ***********************************************************/


### PR DESCRIPTION
Adding back the base stylesheet that WP needs to recognise and activate the theme.

CC: @oliwright1994 / @Jenvbs / @BumbleBebis / @dannysmith 