### PR TITLE
Added .eslintrc file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,7 +18,8 @@
   "globals": {
     "jQuery": false,
     "$": false,
-    "_": false
+    "_": false,
+    "wp": false,
   },
   "env": {
     "es6": true,


### PR DESCRIPTION
 Added an eslint configuration file for use with gulp-eslint based on file provided by red-qod. Extends the base eslint recommended settings, some rules to note are the global variables rules which are set to false i.e. read-only so they cannot be overwritten as wp has its own requirements for jQuery notation. Also added global rule to prevent overwrite for "undefined" variable ``wp`` as it is actually defined when used by wordpress.

Linked to issue #42 


