### PR TITLE
Started work on 404.php - WIP

### DIFF
--- a/404.php
+++ b/404.php
@@ -46,10 +46,12 @@ get_header();
 								//Replace with correct template part name
 								get_template_part('template-parts/content', 'studio-search');
 							}
+							echo '</div>';
 							/* Restore original Post Data */
 							wp_reset_postdata();
 						} else {
 							// no posts found
+							echo '<p>No posts found</p>';
 						}
 						?>
 
@@ -72,10 +74,12 @@ get_header();
 								//Replace with correct template part name
 								get_template_part('template-parts/content', 'guestspot-search');
 							}
+							echo '</div>';
 							/* Restore original Post Data */
 							wp_reset_postdata();
 						} else {
 							// no posts found
+							echo '<p>No posts found</p>';
 						}
 						?>
 
@@ -98,10 +102,12 @@ get_header();
 								//Replace with correct template part name
 								get_template_part('template-parts/content', 'artist-search');
 							}
+							echo '</div>';
 							/* Restore original Post Data */
 							wp_reset_postdata();
 						} else {
 							// no posts found
+							echo '<p>No posts found</p>';
 						}
 						?>
 


### PR DESCRIPTION
Added some guidance text to the 404 page suggesting people try a link to the homepage, a search of explore one of the sections below.

The 404 page now contains:
•Link to homepage
•Search bar
• 3 sections entitled "Explore Artists", "Explore Studios", "Explore Guestspot"

For each of the explore sections i used a custom WP_query to get 3 random posts from each post type. To display them i used the ``get_template_part('template-parts/content', $template_name);``
function. This means once we create a template part to display the individual posts in the search results we can use that template part here because well need to display the same information, and we can use the same layout and styling. Maybe put them in a horizontal flexbox to display them nicely on the page. 